### PR TITLE
Reverse iteration (tail -> head) + interrupt iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,15 +192,20 @@ list.isEmpty();
 * ### findAt(index)
     Returns the node at the location provided by `index`
 
-* ### forEach(fn)
+* ### forEach(fn, reverse)
     Utility function to iterate over the list and call the `fn` provided
-    on each node, or element, of the list
+    on each node, or element, of the list. The optional `reverse` parameter
+    is a boolean used to specify the direction of iteration
+    (true: tail -> head, false: head -> tail, default: false)
 
 * ### toArray()
     Returns an array of all the data contained in the list
 
 * ### printList()
     Prints to the console the data property of each node in the list
+
+* ### interruptEnumeration()
+    Interrupts and breaks out of the loop induced by `forEach()`, making partial iterations possible. An iteration cannot be resumed after having been interrupted.
 
 **Available methods for an individual node instance:**
 

--- a/index.js
+++ b/index.js
@@ -435,11 +435,18 @@
          * Utility function to iterate over the list and call the fn provided
          * on each node, or element, of the list
          *
-         * param {object} fn The function to call on each node of the list
+         * @param {object} fn The function to call on each node of the list
+         * @param {bool} reverse Use or not reverse iteration (tail to head), default to false
          */
-        forEach: function(fn) {
+        forEach: function(fn, reverse) {
+          reverse = reverse || false;
+          if (reverse) {
+            this.iterator.reset_reverse();
+            this.iterator.each_reverse(fn)
+          } else {
             this.iterator.reset();
             this.iterator.each(fn);
+          }
         },
 
         /**
@@ -454,6 +461,13 @@
             });
 
             return listArray;
+        },
+
+        /**
+         * Interrupts iteration over the list
+         */
+        interruptEnumeration: function() {
+          this.iterator.interrupt();
         }
     };
 

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -33,6 +33,7 @@
      */
     function Iterator(theList) {
         this.list = theList || null;
+        this.stopIterationFlag = false;
 
         // a pointer the current node in the list that will be returned.
         // initially this will be null since the 'list' will be empty
@@ -106,6 +107,7 @@
         /**
          * Iterates over all nodes in the list and calls the provided callback
          * function with each node as an argument.
+         * Iteration will break if interrupt() is called
          *
          * @param {function} callback the callback function to be called with
          *                   each node of the list as an arg
@@ -113,10 +115,78 @@
         each: function(callback) {
             this.reset();
             var el;
-            while (this.hasNext()) {
+            while (this.hasNext() && !this.stopIterationFlag) {
                 el = this.next();
                 callback(el);
             }
+            this.stopIterationFlag = false;
+        },
+
+        /*
+         * ### REVERSE ITERATION (TAIL -> HEAD) ###
+         */
+
+        /**
+         * Returns the first node in the list and moves the iterator to
+         * point to the second node.
+         *
+         * @returns the first node in the list
+         */
+        last: function() {
+            this.reset_reverse();
+            return this.next_reverse();
+        },
+
+        /**
+         * Resets the iterator to the tail of the list.
+         */
+        reset_reverse: function() {
+            this.currentNode = this.list.getTailNode();
+        },
+
+        /**
+         * Returns the next node in the iteration, when iterating from tail to head
+         *
+         * @returns {object} the next node in the iteration.
+         */
+        next_reverse: function() {
+            var current = this.currentNode;
+            if (this.currentNode !== null) {
+                this.currentNode = this.currentNode.prev;
+            }
+
+            return current;
+        },
+
+        /**
+         * Iterates over all nodes in the list and calls the provided callback
+         * function with each node as an argument,
+         * starting from the tail and going towards the head.
+         * The iteration will break if interrupt() is called.
+         *
+         * @param {function} callback the callback function to be called within
+         *                    each node as an arg
+         */
+        each_reverse: function(callback) {
+          this.reset_reverse();
+          var el;
+          while (this.hasNext() && !this.stopIterationFlag) {
+            el = this.next_reverse();
+            callback(el);
+          }
+          this.stopIterationFlag = false;
+        },
+
+        /*
+         * ### INTERRUPT ITERATION ###
+         */
+
+        /**
+         * Raises interrupt flag (that will stop each() or each_reverse())
+         */
+
+        interrupt: function() {
+          this.stopIterationFlag = true;
         }
     };
 

--- a/test/list.spec.js
+++ b/test/list.spec.js
@@ -69,6 +69,12 @@ describe('Linked List', function() {
               should.not.exist(list.iterator.next());
           });
 
+        it('should return the tail node when iterator.last() is called', function() {
+          populateList(list, 10);
+          var last = list.iterator.last();
+          last.should.equal(list.getTailNode());
+        })
+
         it('should return the head node when iterator.first() is called',
           function() {
               populateList(list, 10);
@@ -95,6 +101,70 @@ describe('Linked List', function() {
             // should be no more element in list
             list.iterator.hasNext().should.equal(false);
         });
+
+        it('should return correct boolean value for hasNext() in reverse order', function() {
+          populateList(list, 3);
+          list.iterator.reset_reverse();
+
+          list.iterator.hasNext().should.equal(true);
+          list.iterator.next_reverse();
+
+          list.iterator.hasNext().should.equal(true);
+          list.iterator.next_reverse();
+
+          list.iterator.hasNext().should.equal(true);
+          list.iterator.next_reverse();
+
+          list.iterator.hasNext().should.equal(false);
+        });
+
+        it('should go through elements from head to tail when calling iterator.each()', function() {
+          populateList(list, 3);
+          var array = [];
+          //expected result
+          var expectedArray = ["test item 1", "test item 2", "test item 3"];
+          var dummyCallback = function(node) {
+            array.push(node.getData());
+          }
+          list.iterator.reset()
+          list.iterator.each(dummyCallback);
+          array.should.be.eql(expectedArray);
+        });
+
+        it('should go through elements from tail to head when calling iterator.each_reverse()', function() {
+          populateList(list, 3);
+          var array = [];
+          var expectedArray = ["test item 3", "test item 2", "test item 1"];
+          var dummyCallback = function(node) {
+            array.push(node.getData());
+          };
+          list.iterator.reset_reverse();
+          list.iterator.each_reverse(dummyCallback);
+          array.should.be.eql(expectedArray);
+        });
+
+        it('should stop in the middle of iteration if iterator.interrupt() is called', function() {
+          populateList(list, 5);
+          var count = 0;
+          var dummyCallback = function(node) {
+            count += 1;
+            if (count === 3) {
+              list.iterator.interrupt();
+            }
+          };
+
+          // head to tail
+          list.iterator.reset();
+          list.iterator.each(dummyCallback);
+          count.should.be.equal(3);
+
+          // tail to head
+          count = 0;
+          list.iterator.reset_reverse();
+          list.iterator.each_reverse(dummyCallback);
+          count.should.be.equal(3);
+        })
+
     });
 
     describe('insert functionality', function() {


### PR DESCRIPTION
Firstly, thanks for the nice module. 
I was working with it on a pretty large list where elements are appended by ascending order of date (the oldest first) and I needed to iterate only over the most recent part of the list. 
I therefore took the opportunity to edit the code ^.^ and added a reverse iteration functionality as well as an interrupt.

It works like this: 
```javascript
// assuming list is a dbly-linked-list containing [1,2,3,4,5]
list.forEach(function(node) {
  console.log(node.getData())
});
//will print 1, 2, 3, 4, 5
list.forEach(function(node) {
  console.log(node.getData())
}, true);
//will print 5, 4, 3, 2, 1
list.forEach(function(node) {
  console.log(node.getData());
  if (node.getData() === 2) {
     list.interruptEnumeration();
  }
}, true);
//will print 5, 4, 3, 2
```
Essentially, this adds an optional `reverse` boolean parameter in the `forEach()` function, so that it defaults to head -> tail enumeration if not specified.

I'm using it as it now, but I figured perhaps some other people might like this little modification. 
_(And by the way, this is the first time I submit a pull request, so if I'm doing something wrong, I'll be glad to receive feedback !!)_